### PR TITLE
add nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,12 +1,20 @@
+# Nose for testing
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
+# Display missing lines of code
 [coverage:report]
 show_missing = True
 
+# Flake8 for linting
 [flake8]
 per-file-ignores =
     */__init__.py: F401 E402
-
+# Pylint for static code
 [pylint.'MESSAGES CONTROL']
 disable=E1101


### PR DESCRIPTION
Configure setup.cfg file to have nosetests display in color by default when running test.